### PR TITLE
Imperative present tense, not present tense

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ request.
 
 * The commit summary line should be *descriptive* yet *succinct*. It should be
   no longer than *50* characters. It should be capitalized and written in
-  present tense. If it is a single sentence, do not put a period at the end:
+  imperative present tense. If it is a single sentence, do not put a period at the end:
 
   ```shell
   # good - present tense, capitalized, less than 50 characters


### PR DESCRIPTION
Simple present tense would be: "Marks huge records as obsolete when clearing hinting faults". The correct tense would be imperative present tense, which is "Mark huge records as obsolete when clearing hinting faults".
