### PR TITLE
Add interactive staging to Commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ request.
 * Each commit should be a single *logical change*. Don't make several
   *logical changes* in one commit. For example, if a patch fixes a bug and
   optimizes the performance of a feature, split it into two separate commits.
+  If you've been working simultaneously on multiple logical changes in a file,
+  use [interactive staging](https://git-scm.herokuapp.com/book/en/v2/Git-Tools-Interactive-Staging)
+  to stage only the logically related changes for each commit:
+
+  ```shell
+  $ git add -i
+  ```
 
 * Don't split a single *logical change* into several commits. For example,
   the implementation of a feature and the corresponding tests should be in the


### PR DESCRIPTION
Commits section encouraged commits of logical changes, but didn't show
how to split multiple logical changes in a file over multiple commits.
