### PR TITLE
Fix command to get the list merged branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ request.
   Tip: Use the following command to list merged branches:
 
   ```shell
-  $ git branch --merged master | grep -v "\* master"`
+  $ git branch --merged master | grep -v "master"
   ```
 
 ## Commits


### PR DESCRIPTION
The command:

```
git branch --merged master | grep -v "\* master"`
```

It can't work: invert-match master. It should be:

```
git branch --merged master | grep -v "master"
```
