### PR TITLE
Fix syntax-highlighting of plain-text on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ holds true that you should apply all of the above *before* pushing it.
   It should also provide any pointers to related resources (eg. link to the
   corresponding issue in a bug tracker):
 
-  ```shell
+  ```text
   Short (50 chars or fewer) summary of changes
 
   More detailed explanatory text, if necessary. Wrap it to


### PR DESCRIPTION
This fixes the example commit message from being highlighted as a shell-script (see attached image) to being highlighted as plain-text (thus, no highlighting).

In the below image, note the `for`, `in`, and `if`, which are each highlighted in red:

<img width="889" alt="highlighting before" src="https://cloud.githubusercontent.com/assets/944406/12216403/41c432f8-b6e0-11e5-82e3-28fab2c322c8.png">
